### PR TITLE
AspectJ on JDK 16+ requires '--add-opens'

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -50,6 +50,7 @@
 					<configuration>
 						<argLine>
 							-javaagent:"${settings.localRepository}"/org/aspectj/aspectjweaver/${aspectj.version}/aspectjweaver-${aspectj.version}.jar
+							--add-opens java.base/java.lang=ALL-UNNAMED
 						</argLine>
 						<useSystemClassLoader>true</useSystemClassLoader>
 						<forkMode>always</forkMode>


### PR DESCRIPTION
So I added `--add-opens java.base/java.lang=ALL-UNNAMED` as described in the  [AspectJ 1.9.7 release notes](https://htmlpreview.github.io/?https://github.com/eclipse/org.aspectj/blob/master/docs/dist/doc/README-197.html).